### PR TITLE
Add project entity

### DIFF
--- a/migrations/V25__project.sql
+++ b/migrations/V25__project.sql
@@ -1,0 +1,59 @@
+
+CREATE TABLE project (
+    id uuid NOT NULL PRIMARY KEY,
+    name VARCHAR(50) NOT NULL CONSTRAINT project_name_unique UNIQUE,
+    energieke_regio_id INTEGER CONSTRAINT project_energieke_regio_id_unique UNIQUE,
+    buurt_codes VARCHAR(50)[] DEFAULT ARRAY []::CHARACTER VARYING[] NOT NULL
+);
+
+-- Migrate projects from table project to survey
+
+INSERT INTO project (id, name)
+SELECT gen_random_uuid(), project FROM company_survey GROUP BY project;
+
+ALTER TABLE company_survey
+    ADD project_id uuid
+        CONSTRAINT fk_company_survey_project_id__id
+            REFERENCES project
+            ON UPDATE RESTRICT ON DELETE RESTRICT;
+
+UPDATE company_survey
+SET project_id = (SELECT id FROM project WHERE name = company_survey.project);
+
+ALTER TABLE company_survey
+    ALTER COLUMN project_id SET NOT NULL;
+
+ALTER TABLE company_survey
+    DROP COLUMN project;
+
+-- Done with project table, now users
+
+CREATE TYPE projectscope AS ENUM ('READ', 'WRITE');
+
+CREATE TABLE user_project (
+    user_id uuid NOT NULL
+        CONSTRAINT fk_user_project_user_id__id
+            REFERENCES "user"
+            ON UPDATE RESTRICT ON DELETE RESTRICT,
+    project_id uuid NOT NULL
+        CONSTRAINT fk_user_project_project_id__id
+            REFERENCES project
+            ON UPDATE RESTRICT ON DELETE RESTRICT,
+    scopes projectscope[] DEFAULT ARRAY []::projectscope[] NOT NULL
+);
+
+INSERT INTO user_project (user_id, project_id, scopes)
+SELECT
+    user_id,
+    project.id,
+    ARRAY['WRITE', 'READ']::projectscope[]
+FROM project
+    JOIN (
+        SELECT
+            id AS user_id,
+            UNNEST(projects) AS project
+       FROM "user"
+    ) AS usr ON usr.project = project.name;
+
+ALTER TABLE "user"
+    DROP COLUMN projects;

--- a/zorm/src/main/kotlin/com/zenmo/orm/Schema.kt
+++ b/zorm/src/main/kotlin/com/zenmo/orm/Schema.kt
@@ -6,7 +6,9 @@ import com.zenmo.orm.dbutil.createEnumTypeSql
 import com.zenmo.orm.dbutil.createKleinverbruikEnumTypeSql
 import com.zenmo.orm.deeplink.DeeplinkTable
 import com.zenmo.orm.energieprestatieonline.RawPandTable
+import com.zenmo.orm.user.ProjectScope
 import com.zenmo.orm.user.table.UserTable
+import com.zenmo.orm.user.table.UserProjectTable
 import com.zenmo.zummon.companysurvey.*
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.SchemaUtils
@@ -21,6 +23,7 @@ val enums = listOf(
     MissingPvReason::class.java,
     TimeSeriesType::class.java,
     TimeSeriesUnit::class.java,
+    ProjectScope::class.java,
 )
 
 val tables = arrayOf(
@@ -30,7 +33,9 @@ val tables = arrayOf(
     TimeSeriesTable,
     RawPandTable,
     UserTable,
+    UserProjectTable,
     DeeplinkTable,
+    ProjectTable,
 )
 
 fun createSchema(db: Database) {

--- a/zorm/src/main/kotlin/com/zenmo/orm/companysurvey/MockSurvey.kt
+++ b/zorm/src/main/kotlin/com/zenmo/orm/companysurvey/MockSurvey.kt
@@ -5,9 +5,9 @@ import java.util.*
 
 val mockSurvey = createMockSurvey()
 
-fun createMockSurvey() = Survey(
+fun createMockSurvey(projectName: String = "Project") = Survey(
     companyName = "Zenmo",
-    zenmoProject = "Project",
+    zenmoProject = projectName,
     personName = "John Doe",
     email = "john@example.com",
     dataSharingAgreed = true,

--- a/zorm/src/main/kotlin/com/zenmo/orm/companysurvey/ProjectRepository.kt
+++ b/zorm/src/main/kotlin/com/zenmo/orm/companysurvey/ProjectRepository.kt
@@ -1,0 +1,37 @@
+package com.zenmo.orm.companysurvey
+
+import com.zenmo.orm.companysurvey.table.ProjectTable
+import com.zenmo.zummon.companysurvey.Project
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.insertReturning
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import java.util.UUID
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.toKotlinUuid
+
+class ProjectRepository(
+    val db: Database
+) {
+    fun saveNewProject(name: String): UUID =
+        transaction(db) {
+            ProjectTable.insertReturning(listOf(ProjectTable.id)) {
+                it[ProjectTable.name] = name
+            }.first()[ProjectTable.id]
+        }
+
+    @OptIn(ExperimentalUuidApi::class)
+    fun getProjectByEnergiekeRegioId(energiekeRegioId: Int): Project =
+        transaction(db) {
+            ProjectTable.selectAll()
+                .map {
+                    Project(
+                        it[ProjectTable.id].toKotlinUuid(),
+                        it[ProjectTable.name],
+                        it[ProjectTable.energiekeRegioId],
+                        it[ProjectTable.buurtCodes],
+                    )
+                }
+                .first()
+        }
+}

--- a/zorm/src/main/kotlin/com/zenmo/orm/companysurvey/table/Project.kt
+++ b/zorm/src/main/kotlin/com/zenmo/orm/companysurvey/table/Project.kt
@@ -1,0 +1,15 @@
+package com.zenmo.orm.companysurvey.table
+
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.VarCharColumnType
+
+object ProjectTable: Table("project") {
+    val id = uuid("id").autoGenerate()
+    override val primaryKey = PrimaryKey(id)
+
+    val name = varchar("name", 50).uniqueIndex()
+    val energiekeRegioId = integer("energieke_regio_id").uniqueIndex().nullable()
+    // Maybe this is sufficient for now.
+    // We may want to introduce a geometry field.
+    val buurtCodes = array<String>("buurt_codes", VarCharColumnType(50)).default(emptyList())
+}

--- a/zorm/src/main/kotlin/com/zenmo/orm/companysurvey/table/Survey.kt
+++ b/zorm/src/main/kotlin/com/zenmo/orm/companysurvey/table/Survey.kt
@@ -13,8 +13,7 @@ object CompanySurveyTable: Table("company_survey") {
     val created = timestamp("created_at").defaultExpression(CurrentTimestamp)
     // Can be fetched at https://energiekeregio.nl/api/v1/zenmo?details=15989
     val energiekeRegioId = uinteger("energieke_regio_id").nullable()
-    // Zenmo project name
-    val project = varchar("project", 50)
+    val projectId = uuid("project_id").references(ProjectTable.id)
 
     val companyName = varchar("company_name", 50)
     val personName = varchar("person_name", 50)

--- a/zorm/src/main/kotlin/com/zenmo/orm/user/ProjectScope.kt
+++ b/zorm/src/main/kotlin/com/zenmo/orm/user/ProjectScope.kt
@@ -1,0 +1,6 @@
+package com.zenmo.orm.user
+
+enum class ProjectScope {
+    READ,
+    WRITE,
+}

--- a/zorm/src/main/kotlin/com/zenmo/orm/user/User.kt
+++ b/zorm/src/main/kotlin/com/zenmo/orm/user/User.kt
@@ -1,6 +1,7 @@
 package com.zenmo.orm.user
 
 data class User(
+    // Keycloak id
     val id: String,
     val projects: List<String>,
     val note: String,

--- a/zorm/src/main/kotlin/com/zenmo/orm/user/UserRepository.kt
+++ b/zorm/src/main/kotlin/com/zenmo/orm/user/UserRepository.kt
@@ -1,8 +1,26 @@
 package com.zenmo.orm.user
 
+import com.zenmo.orm.user.table.UserProjectTable
+import com.zenmo.orm.user.table.UserTable
 import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.batchInsert
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.transactions.transaction
 import java.util.UUID
 
 fun getUserById(db: Database, id: UUID): User? {
     return null
+}
+
+fun saveUser(db: Database, userId: UUID, projectIds: List<UUID>) {
+    transaction(db) {
+        UserTable.insert {
+            it[id] = userId
+        }
+
+        UserProjectTable.batchInsert(projectIds) {
+            this[UserProjectTable.projectId] = it
+            this[UserProjectTable.userId] = userId
+        }
+    }
 }

--- a/zorm/src/main/kotlin/com/zenmo/orm/user/table/User.kt
+++ b/zorm/src/main/kotlin/com/zenmo/orm/user/table/User.kt
@@ -12,12 +12,6 @@ object UserTable: Table("user") {
     override val primaryKey = PrimaryKey(id)
 
     /**
-     * Project the user has full access to.
-     * A future extension would be to specify finegrained privileges like readonly.
-     */
-    val projects = array<String>("projects", VarCharColumnType(50))
-
-    /**
      * Set the users name here for convenience.
      * This is mostly because there is no GUI yet and no logic to display the name from Keycloak.
      */

--- a/zorm/src/main/kotlin/com/zenmo/orm/user/table/UserProject.kt
+++ b/zorm/src/main/kotlin/com/zenmo/orm/user/table/UserProject.kt
@@ -1,0 +1,15 @@
+package com.zenmo.orm.user.table
+
+import com.zenmo.orm.companysurvey.table.ProjectTable
+import com.zenmo.orm.dbutil.enumArray
+import com.zenmo.orm.user.ProjectScope
+import org.jetbrains.exposed.sql.Table
+
+/**
+ * Links a User to the Projects they have access to.
+ */
+object UserProjectTable: Table("user_project") {
+    val userId = reference("user_id", UserTable.id)
+    val projectId = reference("project_id", ProjectTable.id)
+    val scopes = enumArray("scopes", ProjectScope::class).default(emptyList())
+}

--- a/zummon/src/commonMain/kotlin/companysurvey/Project.kt
+++ b/zummon/src/commonMain/kotlin/companysurvey/Project.kt
@@ -1,0 +1,22 @@
+package com.zenmo.zummon.companysurvey
+
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Serializable
+import kotlin.js.ExperimentalJsExport
+import kotlin.js.JsExport
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+@OptIn(ExperimentalJsExport::class)
+@Serializable
+@JsExport
+data class Project
+@OptIn(ExperimentalUuidApi::class)
+constructor(
+    @Contextual
+    val id: Uuid,
+    val name: String,
+    // Project ID aka Energy Hub ID of Energieke Regio.
+    val energiekeRegioId: Int?,
+    val buurtCodes: List<String>,
+)

--- a/zummon/src/commonMain/kotlin/companysurvey/Survey.kt
+++ b/zummon/src/commonMain/kotlin/companysurvey/Survey.kt
@@ -5,6 +5,7 @@ import com.benasher44.uuid.uuid4
 import kotlinx.serialization.Serializable
 import com.zenmo.zummon.BenasherUuidSerializer
 import kotlinx.datetime.*
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsExport
 import kotlinx.serialization.json.Json
@@ -59,6 +60,7 @@ data class Survey(
         return addresses.firstAndOnly().gridConnections.firstAndOnly()
     }
 
+    @OptIn(ExperimentalSerializationApi::class)
     public fun toPrettyJson(): String {
         val prettyJson = Json { // this returns the JsonBuilder
             prettyPrint = true
@@ -96,6 +98,7 @@ private fun <T> List<T>.firstAndOnly(): T {
     return this.first()
 }
 
+@OptIn(ExperimentalJsExport::class)
 @JsExport
 @Serializable
 data class SurveyWithErrors(

--- a/zummon/src/commonMain/kotlin/companysurvey/TimeSeries.kt
+++ b/zummon/src/commonMain/kotlin/companysurvey/TimeSeries.kt
@@ -5,12 +5,14 @@ import kotlin.time.Duration.Companion.minutes
 import com.benasher44.uuid.Uuid
 import com.benasher44.uuid.uuid4
 import com.zenmo.zummon.BenasherUuidSerializer
+import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsExport
 
 
 /**
  * This contains values parsed from a CSV/excel or fetched from an API.
  */
+@OptIn(ExperimentalJsExport::class)
 @JsExport
 @Serializable
 data class TimeSeries (
@@ -59,12 +61,14 @@ data class TimeSeries (
     }
 }
 
+@OptIn(ExperimentalJsExport::class)
 @JsExport
 enum class TimeSeriesUnit {
     KWH,
     M3,
 }
 
+@OptIn(ExperimentalJsExport::class)
 @JsExport
 enum class TimeSeriesType {
     // Delivery from grid to end-user


### PR DESCRIPTION
New table for Project data. This holds the project name, area and Energieke Regio energy hub id.

Previously the project name was a natural
key in User and Survey. This is now migrated.

The data access objects have backwards compatibility with the old approach.