### PR TITLE
Fudge year

### DIFF
--- a/zorm/src/test/java/com/zenmo/orm/companysurvey/InteropTest.java
+++ b/zorm/src/test/java/com/zenmo/orm/companysurvey/InteropTest.java
@@ -1,7 +1,13 @@
 package com.zenmo.orm.companysurvey;
 
 import com.zenmo.zummon.companysurvey.Address;
+import com.zenmo.zummon.companysurvey.GridConnection;
+import com.zenmo.zummon.companysurvey.PandID;
+import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
+
+import java.util.Set;
+
 import static org.junit.Assert.*;
 
 public class InteropTest {
@@ -11,5 +17,11 @@ public class InteropTest {
         Address address = mocksurvey.getAddresses().get(0);
         int houseNumber = address.getHouseNumber();
         assertEquals(35, houseNumber);
+
+        GridConnection gc = address.getGridConnections().get(0);
+        Set<PandID> pandIds = gc.getPandIds();
+        System.out.println(pandIds);
+
+        var isEmpty = gc.getElectricity().getQuarterHourlyFeedIn_kWh().getValues().length == 0;
     }
 }

--- a/zummon/build.gradle.kts
+++ b/zummon/build.gradle.kts
@@ -36,5 +36,10 @@ kotlin {
                 implementation("com.benasher44:uuid:0.8.4")
             }
         }
+        commonTest {
+            dependencies {
+                implementation(kotlin("test"))
+            }
+        }
     }
 }

--- a/zummon/src/commonMain/kotlin/companysurvey/TimeSeries.kt
+++ b/zummon/src/commonMain/kotlin/companysurvey/TimeSeries.kt
@@ -2,9 +2,13 @@ package com.zenmo.zummon.companysurvey
 
 import kotlinx.serialization.Serializable
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.days
 import com.benasher44.uuid.Uuid
 import com.benasher44.uuid.uuid4
 import com.zenmo.zummon.BenasherUuidSerializer
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
 import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsExport
 
@@ -20,13 +24,69 @@ data class TimeSeries (
     val id: Uuid = uuid4(),
     val type: TimeSeriesType,
     // Measurement start time
-    val start: kotlinx.datetime.Instant,
+    val start: Instant,
     val timeStep: kotlin.time.Duration = 15.minutes,
     val unit: TimeSeriesUnit = TimeSeriesUnit.KWH,
     val values: FloatArray = floatArrayOf(),
 ) {
     @Deprecated("Use .values", ReplaceWith("values"))
     fun getFlatDataPoints(): FloatArray = values
+
+    fun calculateEnd(): Instant = start + (timeStep * values.size)
+
+    /**
+     * The number of values needed to fill a year using the specified time step.
+     */
+    fun numValuesNeededForFullYear() = (1.days / timeStep * 365).toInt()
+
+    fun hasNumberOfValuesForOneYear() = values.size >= numValuesNeededForFullYear()
+
+    fun assertHasNumberOfValuesForOneYear(): Unit {
+        val numValuesNeededForFullYear = numValuesNeededForFullYear()
+        if (values.size < numValuesNeededForFullYear) {
+            throw Exception("Not enough values for year: needed $numValuesNeededForFullYear got ${values.size}")
+        }
+    }
+
+    /**
+     * Get a full calendar year of data if it is present.
+     * If it isn't, put together a year by appending the last part of the previous year to the data of the most-recent year.
+     * Always returns 365 days worth of values.
+     */
+    fun getFullYearOrFudgeIt(year: Int): FloatArray {
+        assertHasNumberOfValuesForOneYear()
+
+        val startOfYear = Instant.parse("$year-01-01T00:00:00+01:00")
+        // can be negative
+        val diff = startOfYear - start
+        val numValuesToSliceOffStart = (diff / timeStep).toInt()
+
+        if (numValuesToSliceOffStart >= 0) {
+            val rangeEnd = numValuesToSliceOffStart + numValuesNeededForFullYear()
+            if (rangeEnd > values.size) {
+                return sliceMostRecentDataToAlignedYear()
+            }
+            return values.sliceArray(IntRange(numValuesToSliceOffStart, rangeEnd - 1))
+        } else {
+            return sliceMostRecentDataToAlignedYear()
+        }
+    }
+
+    /**
+     * Put together a year of data by appending the last part of the previous year to the data of the most-recent year.
+     * Always returns 365 days worth of values.
+     */
+    fun sliceMostRecentDataToAlignedYear(): FloatArray {
+        assertHasNumberOfValuesForOneYear()
+
+        val end = calculateEnd()
+        val year = end.toLocalDateTime(TimeZone.of("Europe/Amsterdam")).year
+        val start = Instant.parse("$year-01-01T00:00:00+01:00")
+        val numValuesInCurrentYear = ((end - start) / timeStep).toInt()
+
+        return values.sliceArray(IntRange(values.size - numValuesInCurrentYear, values.size - 1))
+            .plus(values.sliceArray(IntRange(values.size - numValuesNeededForFullYear(), values.size - numValuesInCurrentYear - 1)))
+    }
 
     /**
      * Generated code

--- a/zummon/src/commonTest/kotlin/companysurvey/TimeSeriesTest.kt
+++ b/zummon/src/commonTest/kotlin/companysurvey/TimeSeriesTest.kt
@@ -1,0 +1,115 @@
+package companysurvey
+
+import com.zenmo.zummon.companysurvey.TimeSeries
+import com.zenmo.zummon.companysurvey.TimeSeriesType
+import kotlinx.datetime.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TimeSeriesTest {
+    @Test
+    fun testEndOfEmptyTimeSeries() {
+        val timeSeries = TimeSeries(
+            type = TimeSeriesType.ELECTRICITY_DELIVERY,
+            start = Instant.parse("2023-01-01T00:00:00+01:00"),
+        )
+
+        assertEquals(timeSeries.start, timeSeries.calculateEnd())
+        assertFalse(timeSeries.hasNumberOfValuesForOneYear())
+    }
+
+    @Test
+    fun testEndOfTwoAndAHalfDaySeries() {
+        val timeSeries = TimeSeries(
+            type = TimeSeriesType.ELECTRICITY_DELIVERY,
+            start = Instant.parse("2023-01-01T00:00:00Z"),
+            values = generateSequence { 0.0f }.take((2.5 * 4 * 24).toInt()).toList().toFloatArray()
+        )
+
+        assertEquals(
+            Instant.parse("2023-01-03T12:00:00Z"),
+            timeSeries.calculateEnd()
+        )
+        assertFalse(timeSeries.hasNumberOfValuesForOneYear())
+    }
+
+    @Test
+    fun testFullYear() {
+        val timeSeries = TimeSeries(
+            type = TimeSeriesType.ELECTRICITY_DELIVERY,
+            start = Instant.parse("2023-01-01T00:00:00+01:00"),
+            values = iterator {
+                yield(100f)
+                yieldAll(generateSequence { 0.0f }.take((365 * 4 * 24) - 2))
+                yield(200f)
+            }.asSequence().toList().toFloatArray()
+        )
+
+        assertTrue(timeSeries.hasNumberOfValuesForOneYear())
+        val yearValues = timeSeries.getFullYearOrFudgeIt(2023)
+        assertEquals(100f, yearValues.first())
+        assertEquals(200f, yearValues.last())
+        assertEquals(300f, yearValues.sum(), 0.001f)
+    }
+
+    @Test
+    fun testFullYearPlusOne() {
+        val timeSeries = TimeSeries(
+            type = TimeSeriesType.ELECTRICITY_DELIVERY,
+            start = Instant.parse("2022-12-31T23:45:00+01:00"),
+            values = iterator {
+                yield(100f) // outside of year
+                yield(200f) // jan 1st
+                yieldAll(generateSequence { 0.0f }.take((365 * 4 * 24) - 2))
+                yield(300f) // dec 31st
+                yield(400f) // outside of year
+            }.asSequence().toList().toFloatArray()
+        )
+
+        assertTrue(timeSeries.hasNumberOfValuesForOneYear())
+        val yearValues = timeSeries.getFullYearOrFudgeIt(2023)
+        assertEquals(200f, yearValues.first())
+        assertEquals(300f, yearValues.last())
+        assertEquals(500f, yearValues.sum(), 0.001f)
+    }
+
+    @Test
+    fun testAlmostFullYear() {
+        val timeSeries = TimeSeries(
+            type = TimeSeriesType.ELECTRICITY_DELIVERY,
+            start = Instant.parse("2023-01-01T00:00:00+01:00"),
+            values = generateSequence { 1f }.take(((365 * 4 * 24) -1)).toList().toFloatArray()
+        )
+
+        assertFalse(timeSeries.hasNumberOfValuesForOneYear())
+        assertFails {
+            timeSeries.getFullYearOrFudgeIt(2023)
+        }
+    }
+
+    @Test
+    fun testFudgeYear() {
+        val timeSeries = TimeSeries(
+            type = TimeSeriesType.ELECTRICITY_DELIVERY,
+            start = Instant.parse("2023-07-01T00:00:00+01:00"),
+            values = iterator {
+                yield(100f)
+                yieldAll(generateSequence { 0.0f }.take((184 * 4 * 24) - 2))
+                yield(200f) // dec 31st
+                yield(300f) // jan 1st
+                yieldAll(generateSequence { 0.0f }.take((181 * 4 * 24) - 2))
+                yield(400f)
+            }.asSequence().toList().toFloatArray()
+        )
+
+        assertTrue(timeSeries.hasNumberOfValuesForOneYear())
+        val yearValues = timeSeries.getFullYearOrFudgeIt(2023)
+        assertEquals(timeSeries.numValuesNeededForFullYear(), yearValues.size)
+        assertEquals(1000f, yearValues.sum(), 0.1f)
+        assertEquals(300f, yearValues.first())
+        assertEquals(200f, yearValues.last())
+    }
+}


### PR DESCRIPTION
If the time series does not contain the requested year, fudge a year by appending the last part of the previous year to the data of the most-recent year.