### PR TITLE
quarter-hourly peak validation fix

### DIFF
--- a/zummon/src/commonMain/kotlin/companysurvey/Electricity.kt
+++ b/zummon/src/commonMain/kotlin/companysurvey/Electricity.kt
@@ -34,23 +34,29 @@ data class Electricity (
     fun getHasConnection(): Boolean {
         return hasConnection ?: false
     }
-    
+
+    /**
+     * Contracted capacity for delivery of electricity from grid to company.
+     */
     fun getContractedConnectionCapacityKw(): Double? {
-        when(kleinverbruikOrGrootverbruik) {
-            KleinverbruikOrGrootverbruik.GROOTVERBRUIK -> return grootverbruik?.contractedConnectionDeliveryCapacity_kW?.toDouble()
-            KleinverbruikOrGrootverbruik.KLEINVERBRUIK -> return kleinverbruik?.connectionCapacity?.toKw()
-            else -> return kleinverbruik?.connectionCapacity?.toKw() ?: grootverbruik?.contractedConnectionDeliveryCapacity_kW?.toDouble()
+        return when (kleinverbruikOrGrootverbruik) {
+            KleinverbruikOrGrootverbruik.GROOTVERBRUIK -> grootverbruik?.contractedConnectionDeliveryCapacity_kW?.toDouble()
+            KleinverbruikOrGrootverbruik.KLEINVERBRUIK -> kleinverbruik?.connectionCapacity?.toKw()
+            else -> kleinverbruik?.connectionCapacity?.toKw() ?: grootverbruik?.contractedConnectionDeliveryCapacity_kW?.toDouble()
         }
     }
 
     fun getPhysicalConnectionCapacityKw(): Double? {
-        when(kleinverbruikOrGrootverbruik) {
-            KleinverbruikOrGrootverbruik.GROOTVERBRUIK -> return grootverbruik?.physicalCapacityKw?.toDouble()
-            KleinverbruikOrGrootverbruik.KLEINVERBRUIK -> return kleinverbruik?.connectionCapacity?.toKw()
-            else -> return kleinverbruik?.connectionCapacity?.toKw() ?: grootverbruik?.physicalCapacityKw?.toDouble()
+        return when (kleinverbruikOrGrootverbruik) {
+            KleinverbruikOrGrootverbruik.GROOTVERBRUIK -> grootverbruik?.physicalCapacityKw?.toDouble()
+            KleinverbruikOrGrootverbruik.KLEINVERBRUIK -> kleinverbruik?.connectionCapacity?.toKw()
+            else -> kleinverbruik?.connectionCapacity?.toKw() ?: grootverbruik?.physicalCapacityKw?.toDouble()
         }
     }
 
+    /**
+     * Contracted capacity for feed-in of electricity from company to grid.
+     */
     fun getContractedFeedInCapacityKw(): Double? {
         when (kleinverbruikOrGrootverbruik) {
             KleinverbruikOrGrootverbruik.GROOTVERBRUIK -> return grootverbruik?.contractedConnectionFeedInCapacity_kW?.toDouble()

--- a/zummon/src/commonMain/kotlin/companysurvey/TimeSeries.kt
+++ b/zummon/src/commonMain/kotlin/companysurvey/TimeSeries.kt
@@ -3,6 +3,7 @@ package com.zenmo.zummon.companysurvey
 import kotlinx.serialization.Serializable
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
 import com.benasher44.uuid.Uuid
 import com.benasher44.uuid.uuid4
 import com.zenmo.zummon.BenasherUuidSerializer
@@ -76,6 +77,7 @@ data class TimeSeries (
         return maxNullSequence
     }
 
+    fun getPeak(): DataPoint = DataPoint(values.max(), unit, timeStep)
 
     /**
      * Get a full calendar year of data if it is present.
@@ -165,4 +167,30 @@ enum class TimeSeriesType {
     // Solar panel production
     ELECTRICITY_PRODUCTION,
     GAS_DELIVERY,
+}
+
+/**
+ * Represents a single point within the time series.
+ * Improvement: add timestamp
+ */
+data class DataPoint (
+    val value: Float,
+    val unit: TimeSeriesUnit,
+    val timeStep: kotlin.time.Duration,
+) {
+    fun kWh(): Double {
+        if (this.unit != TimeSeriesUnit.KWH) {
+            throw UnsupportedOperationException("Can only get the kWh from a kWh data point")
+        }
+
+        return value.toDouble()
+    }
+
+    fun kW(): Double {
+        if (this.unit != TimeSeriesUnit.KWH) {
+            throw UnsupportedOperationException("Can only get the kW from a kWh data point")
+        }
+
+        return value * (1.hours / this.timeStep)
+    }
 }

--- a/zummon/src/commonTest/kotlin/companysurvey/TimeSeriesTest.kt
+++ b/zummon/src/commonTest/kotlin/companysurvey/TimeSeriesTest.kt
@@ -112,4 +112,17 @@ class TimeSeriesTest {
         assertEquals(300f, yearValues.first())
         assertEquals(200f, yearValues.last())
     }
+
+    @Test
+    fun testGetPeakKw() {
+        val timeSeries = TimeSeries(
+            type = TimeSeriesType.ELECTRICITY_DELIVERY,
+            start = Instant.parse("2024-01-01T00:00:00+01:00"),
+            values = floatArrayOf(1f, 2f, 1f)
+        )
+
+        val peak = timeSeries.getPeak()
+        assertEquals(2.0, peak.kWh())
+        assertEquals(8.0, peak.kW())
+    }
 }


### PR DESCRIPTION
The validation mixed kWh and kW. The timeseries is now converted to kW before comparison.