### PR TITLE
Set electricity data ingress type radio

### DIFF
--- a/frontend/src/components/company-survey-v2/electricity-data.tsx
+++ b/frontend/src/components/company-survey-v2/electricity-data.tsx
@@ -11,7 +11,7 @@ export const ElectricityData = ({form, prefix, project}: {
     prefix: string,
     project: ProjectConfiguration,
 }) => {
-    const [consumptionSpec, setConsumptionSpec] = useState<ConsumptionSpec | null | undefined>()
+    const [consumptionSpec, setConsumptionSpec] = useState<ConsumptionSpec | null | undefined>(initialRadioValue(form, prefix))
 
     return (
         <>
@@ -84,4 +84,16 @@ export const ElectricityData = ({form, prefix, project}: {
             {/*)}*/}
         </>
     )
+}
+
+function initialRadioValue(form: UseFormReturn, prefix: string): ConsumptionSpec | null {
+    if (form.getValues(`${prefix}.quarterHourlyDelivery_kWh`)) {
+        return ConsumptionSpec.TEXTAREA
+    }
+
+    if (form.getValues(`${prefix}.authorizationFile`)) {
+        return ConsumptionSpec.PDF_AUTHORIZATION
+    }
+
+    return null
 }


### PR DESCRIPTION
If the user has already used a way to supply timeseries electricity data, make sure the radio button indicates that after opening the form.