### PR TITLE
TimeSeries: bigger step (backend)

### DIFF
--- a/excel-read-named-v5/src/main/kotlin/excelreadnamed/v5/CompanyDataDocument.kt
+++ b/excel-read-named-v5/src/main/kotlin/excelreadnamed/v5/CompanyDataDocument.kt
@@ -2,6 +2,7 @@ package com.zenmo.excelreadnamed.v5
 
 import com.zenmo.zummon.companysurvey.*
 import com.zenmo.zummon.companysurvey.TimeSeriesUnit
+import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.Instant
 import org.apache.poi.ss.usermodel.CellType
 import org.apache.poi.ss.util.AreaReference
@@ -465,8 +466,8 @@ data class CompanyDataDocument(
             type = type,
             start = start,
             timeStep = when (type) {
-                TimeSeriesType.GAS_DELIVERY -> 1.hours
-                else -> 15.minutes
+                TimeSeriesType.GAS_DELIVERY -> DateTimeUnit.HOUR
+                else -> DateTimeUnit.MINUTE * 15
             },
             unit = TimeSeriesUnit.KWH,
             values = values
@@ -484,7 +485,7 @@ data class CompanyDataDocument(
         return TimeSeries(
             type = soortProfiel.timeSeriesType(),
             start = yearToFirstOfJanuary(metadata.jaar),
-            timeStep = metadata.resolutieMinuten.minutes,
+            timeStep = DateTimeUnit.MINUTE * metadata.resolutieMinuten,
             unit = metadata.eenheid,
             values = getArrayField("profileData${metadata.index}")
         )

--- a/excel-read-named-v5/src/test/kotlin/ReadExcelTest.kt
+++ b/excel-read-named-v5/src/test/kotlin/ReadExcelTest.kt
@@ -2,6 +2,7 @@ package com.zenmo.excelreadnamed.v5
 
 import com.zenmo.zummon.companysurvey.TimeSeriesType
 import com.zenmo.zummon.companysurvey.TimeSeriesUnit
+import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -19,7 +20,7 @@ class ReadExcelTest {
         val deliveryTimeSeries = survey.getSingleGridConnection().electricity.quarterHourlyDelivery_kWh
         assertNotNull(deliveryTimeSeries)
 
-        assertEquals(15.minutes, deliveryTimeSeries.timeStep)
+        assertEquals(DateTimeUnit.MINUTE * 15, deliveryTimeSeries.timeStep)
         assertEquals(Instant.parse("2023-01-01T00:00:00+01"), deliveryTimeSeries.start)
         assertEquals(365 * 24 * 4, deliveryTimeSeries.values.size)
         assertEquals(listOf(1.2f, 2.2f, 3.2f), deliveryTimeSeries.values.sliceArray(0..2).toList())

--- a/zorm/src/main/kotlin/com/zenmo/orm/companysurvey/MockSurvey.kt
+++ b/zorm/src/main/kotlin/com/zenmo/orm/companysurvey/MockSurvey.kt
@@ -1,6 +1,7 @@
 package com.zenmo.orm.companysurvey
 
 import com.zenmo.zummon.companysurvey.*
+import kotlinx.datetime.DateTimeUnit
 import java.util.*
 import kotlin.time.Duration.Companion.hours
 
@@ -110,7 +111,7 @@ fun createMockSurvey(projectName: String = "Project") = Survey(
                         hourlyDelivery_m3 = TimeSeries(
                             type = TimeSeriesType.GAS_DELIVERY,
                             start = kotlinx.datetime.Instant.parse("2022-01-01T00:00:00+01"),
-                            timeStep = 2.hours,
+                            timeStep = DateTimeUnit.HOUR * 2,
                             values = floatArrayOf(1.2f, 2.2f, 3.2f, 4.2f),
                         )
                     ),

--- a/zorm/src/main/kotlin/com/zenmo/orm/companysurvey/table/TimeSeries.kt
+++ b/zorm/src/main/kotlin/com/zenmo/orm/companysurvey/table/TimeSeries.kt
@@ -2,13 +2,13 @@ package com.zenmo.orm.companysurvey.table
 
 import com.zenmo.orm.dbutil.PGEnum
 import com.zenmo.orm.dbutil.ZenmoUUIDTable
-import com.zenmo.orm.dbutil.interval
+import com.zenmo.orm.dbutil.dateTimeUnit
 import com.zenmo.zummon.companysurvey.TimeSeriesType
 import com.zenmo.zummon.companysurvey.TimeSeriesUnit
+import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.Instant
 import org.jetbrains.exposed.sql.ReferenceOption
 import org.jetbrains.exposed.sql.kotlin.datetime.timestamp
-import kotlin.time.Duration.Companion.minutes
 
 object TimeSeriesTable: ZenmoUUIDTable("time_series") {
     // The grid connection this time series belongs to
@@ -22,7 +22,7 @@ object TimeSeriesTable: ZenmoUUIDTable("time_series") {
         fromDb = { TimeSeriesType.valueOf(it as String) },
         toDb = { PGEnum(TimeSeriesType::class.simpleName!!, it) })
     val start = timestamp("start").default(Instant.parse("2023-01-01T00:00:00+01"))
-    val timeStep = interval("time_step").default(15.minutes)
+    val timeStep = dateTimeUnit("time_step").default(DateTimeUnit.MINUTE * 15)
     val unit = customEnumeration(
         "unit",
         TimeSeriesUnit::class.simpleName,

--- a/zorm/src/main/kotlin/com/zenmo/orm/dbutil/DateTimeUnitColumnType.kt
+++ b/zorm/src/main/kotlin/com/zenmo/orm/dbutil/DateTimeUnitColumnType.kt
@@ -1,0 +1,78 @@
+package com.zenmo.orm.dbutil
+
+import kotlinx.datetime.DateTimeUnit
+import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.ColumnType
+import org.jetbrains.exposed.sql.Table
+import org.postgresql.util.PGInterval
+
+/**
+ * Map PostgreSQL Interval type to Kotlin DateTimeUnit type.
+ * Implemented up to whole second granularity.
+ */
+class DateTimeUnitColumnType : ColumnType<DateTimeUnit>() {
+    override fun sqlType(): String = "INTERVAL"
+
+    override fun notNullValueToDB(value: DateTimeUnit): PGInterval {
+        return when (value) {
+            is DateTimeUnit.TimeBased -> {
+                val hours =  value.duration.inWholeHours.toInt()
+                if (hours > 0 ) {
+                    return PGInterval(0, 0, 0, hours, 0, 0.0)
+                }
+
+                val minutes = value.duration.inWholeMinutes.toInt()
+                if (minutes > 0 ) {
+                    return PGInterval(0, 0, 0, 0, minutes, 0.0)
+                }
+
+                val seconds = value.duration.inWholeSeconds
+                if (seconds > 0) {
+                    return PGInterval(0, 0, 0, 0, 0, seconds.toDouble())
+                }
+
+                throw Exception("Mapping DateTimeUnit ${value.duration.toIsoString()} to database is not implemented")
+            }
+
+            is DateTimeUnit.DayBased -> PGInterval(0, 0, value.days, 0, 0, 0.0)
+            is DateTimeUnit.MonthBased -> PGInterval(0, value.months, 0, 0, 0, 0.0)
+        }
+    }
+
+    private val regex = "^(?<years>\\d+) years (?<months>\\d+) mons (?<days>\\d+) days (?<hours>\\d+) hours (?<minutes>\\d+) mins (?<seconds>\\d+).0 secs$".toRegex()
+
+    override fun valueFromDB(value: Any): DateTimeUnit? {
+        if (value !is String) {
+            return valueFromDB(value.toString())
+        }
+
+        val match =  regex.find(value) ?: throw Exception("Unrecognised postgres interval format: $value")
+        val groupValues = match.groupValues
+
+        val years = groupValues[1].toInt()
+        val months = groupValues[2].toInt()
+        val days = groupValues[3].toInt()
+        val hours = groupValues[4].toInt()
+        val minutes = groupValues[5].toInt()
+        val seconds = groupValues[6].toInt()
+
+        return when {
+            years > 0 -> DateTimeUnit.YEAR * years
+            months > 0 -> DateTimeUnit.MONTH * months
+            days > 0 -> DateTimeUnit.DAY * days
+            hours > 0 -> DateTimeUnit.HOUR * hours
+            minutes > 0 -> DateTimeUnit.MINUTE * minutes
+            seconds > 0 -> DateTimeUnit.SECOND * seconds
+            else -> throw Exception("Got empty postgres interval: $value")
+        }
+    }
+
+    override fun nonNullValueAsDefaultString(value: DateTimeUnit): String =
+        buildString {
+            append("'")
+            append(notNullValueToDB(value).toString())
+            append("'::interval")
+        }
+}
+
+fun Table.dateTimeUnit(name: String): Column<DateTimeUnit> = registerColumn(name, DateTimeUnitColumnType())

--- a/zorm/src/test/kotlin/com/zenmo/orm/companysurvey/SurveyRepositoryTest.kt
+++ b/zorm/src/test/kotlin/com/zenmo/orm/companysurvey/SurveyRepositoryTest.kt
@@ -5,6 +5,7 @@ import com.zenmo.orm.companysurvey.table.CompanySurveyTable
 import com.zenmo.orm.connectToPostgres
 import com.zenmo.orm.user.UserRepository
 import com.zenmo.zummon.companysurvey.Survey
+import com.zenmo.zummon.companysurvey.toDuration
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import java.util.UUID
@@ -57,7 +58,7 @@ class SurveyRepositoryTest {
         assertEquals(survey, storedSurvey)
         val gasTimeStep = storedSurvey.addresses.single().gridConnections.single().naturalGas.hourlyDelivery_m3?.timeStep
         assertNotNull(gasTimeStep)
-        assertEquals(2, gasTimeStep.inWholeHours)
+        assertEquals(2, gasTimeStep.toDuration().inWholeHours)
     }
 
     @Test

--- a/ztor/src/main/kotlin/com/zenmo/ztor/FuduraImport.kt
+++ b/ztor/src/main/kotlin/com/zenmo/ztor/FuduraImport.kt
@@ -14,6 +14,7 @@ import com.zenmo.zummon.companysurvey.TimeSeries
 import com.zenmo.zummon.companysurvey.TimeSeriesType
 import com.zenmo.zummon.companysurvey.TimeSeriesUnit
 import kotlinx.datetime.Clock
+import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.Instant
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.minutes
@@ -163,7 +164,7 @@ fun createTimeSeries(
     type = getTimeSeriesType(channelMetadata, meteringPointId) ?: throw Exception("Unmapped time series type"),
     // Measurement start time
     start = Instant.parse(telemetry.first().readingTimestamp),
-    timeStep = 15.minutes,
+    timeStep = DateTimeUnit.MINUTE * 15,
     unit = TimeSeriesUnit.KWH,
     values = telemetry.map {
         it.value.toFloat()

--- a/zummon/src/commonMain/kotlin/companysurvey/TimeSeries.kt
+++ b/zummon/src/commonMain/kotlin/companysurvey/TimeSeries.kt
@@ -2,18 +2,17 @@ package com.zenmo.zummon.companysurvey
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
-import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
 import com.benasher44.uuid.Uuid
 import com.benasher44.uuid.uuid4
 import com.zenmo.zummon.BenasherUuidSerializer
-import kotlinx.datetime.Instant
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
+import kotlinx.datetime.*
 import kotlinx.serialization.encodeToString
 import kotlin.js.JsExport
+import kotlin.math.roundToInt
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.nanoseconds
 
 /**
  * This contains values parsed from a CSV/excel or fetched from an API.
@@ -26,15 +25,19 @@ data class TimeSeries (
     val type: TimeSeriesType,
     /** Start of the first measurement interval */
     val start: Instant,
-    /** Duration of the measurement interval */
-    val timeStep: Duration = type.defaultStep(),
+    /**
+     * Duration of the measurement interval.
+     * It would be easier to use [DateTimeUnit.TimeBased] or [Duration] instead of [DateTimeUnit]
+     * but then we would lose the ability to process month-based time series.
+     */
+    val timeStep: DateTimeUnit = type.defaultStep(),
     val unit: TimeSeriesUnit = type.defaultUnit(),
     val values: FloatArray = floatArrayOf(),
 ) {
     @Deprecated("Use .values", ReplaceWith("values"))
     fun getFlatDataPoints(): FloatArray = values
 
-    fun calculateEnd(): Instant = start + (timeStep * values.size)
+    fun calculateEnd(): Instant = start.plus(values.size, timeStep, TimeZone.of("Europe/Amsterdam"))
 
     fun sum(): Float = values.sum()
 
@@ -46,8 +49,9 @@ data class TimeSeries (
 
     /**
      * The number of values needed to fill a year using the specified time step.
+     * So far our simulation always assumes 365 days in a year.
      */
-    fun numValuesNeededForFullYear() = (1.days / timeStep * 365).toInt()
+    fun numValuesNeededForFullYear() = (DateTimeUnit.YEAR.toDuration() / timeStep.toDuration()).roundToInt()
 
     fun hasNumberOfValuesForOneYear() = values.size >= numValuesNeededForFullYear()
 
@@ -105,7 +109,7 @@ data class TimeSeries (
         val startOfYear = Instant.parse("$year-01-01T00:00:00+01:00")
         // can be negative
         val diff = startOfYear - start
-        val numValuesToSliceOffStart = (diff / timeStep).toInt()
+        val numValuesToSliceOffStart = (diff / timeStep.toDuration()).toInt()
 
         if (numValuesToSliceOffStart >= 0) {
             val rangeEnd = numValuesToSliceOffStart + numValuesNeededForFullYear()
@@ -128,7 +132,7 @@ data class TimeSeries (
         val end = calculateEnd()
         val year = end.toLocalDateTime(TimeZone.of("UTC+01:00")).year
         val start = Instant.parse("$year-01-01T00:00:00+01:00")
-        val numValuesInCurrentYear = ((end - start) / timeStep).toInt()
+        val numValuesInCurrentYear = ((end - start) / timeStep.toDuration()).toInt()
 
         return values.sliceArray(IntRange(values.size - numValuesInCurrentYear, values.size - 1))
             .plus(values.sliceArray(IntRange(values.size - numValuesNeededForFullYear(), values.size - numValuesInCurrentYear - 1)))
@@ -183,25 +187,25 @@ enum class TimeSeriesType {
     // Delivery from grid to end-user
     ELECTRICITY_DELIVERY {
         override fun defaultUnit() = TimeSeriesUnit.KWH
-        override fun defaultStep() = 15.minutes
+        override fun defaultStep() = DateTimeUnit.MINUTE * 15
     },
     // Feed-in of end-user back in to the rid
     ELECTRICITY_FEED_IN {
         override fun defaultUnit() = TimeSeriesUnit.KWH
-        override fun defaultStep() = 15.minutes
+        override fun defaultStep() = DateTimeUnit.MINUTE * 15
     },
     // Solar panel production
     ELECTRICITY_PRODUCTION {
         override fun defaultUnit() = TimeSeriesUnit.KWH
-        override fun defaultStep() = 15.minutes
+        override fun defaultStep() = DateTimeUnit.MINUTE * 15
     },
     GAS_DELIVERY {
         override fun defaultUnit() = TimeSeriesUnit.M3
-        override fun defaultStep() = 1.hours
+        override fun defaultStep() = DateTimeUnit.HOUR
     };
 
     abstract fun defaultUnit(): TimeSeriesUnit
-    abstract fun defaultStep(): Duration
+    abstract fun defaultStep(): DateTimeUnit
 }
 
 @JsExport
@@ -218,7 +222,7 @@ fun createEmptyTimeSeriesForYear(type: TimeSeriesType, year: Int) =
 data class DataPoint (
     val value: Float,
     val unit: TimeSeriesUnit,
-    val timeStep: kotlin.time.Duration,
+    val timeStep: DateTimeUnit,
 ) {
     fun kWh(): Double {
         if (this.unit != TimeSeriesUnit.KWH) {
@@ -233,9 +237,19 @@ data class DataPoint (
             throw UnsupportedOperationException("Can only get the kW from a kWh data point")
         }
 
-        return value * (1.hours / this.timeStep)
+        return value * (1.hours / this.timeStep.toDuration())
     }
 }
 
 @JsExport
 fun instantToEpochSeconds(instant: Instant) = instant.epochSeconds.toDouble()
+
+/**
+ * This assumes a 365-day year.
+ * It looks like we will stick with this assumption in the simulation so we might get away with this.
+ */
+fun DateTimeUnit.toDuration(): Duration = when (this) {
+    is DateTimeUnit.DayBased -> this.days.days
+    is DateTimeUnit.MonthBased -> (this.months.toDouble() * (365.0 / 12.0)).days
+    is DateTimeUnit.TimeBased -> this.nanoseconds.nanoseconds
+}

--- a/zummon/src/commonTest/kotlin/companysurvey/MockSurvey.kt
+++ b/zummon/src/commonTest/kotlin/companysurvey/MockSurvey.kt
@@ -2,6 +2,7 @@ package companysurvey
 
 import com.benasher44.uuid.uuid4
 import com.zenmo.zummon.companysurvey.*
+import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.Instant
 import kotlin.time.Duration.Companion.hours
 
@@ -110,7 +111,7 @@ fun createMockSurvey(projectName: String = "Project") = Survey(
                         hourlyDelivery_m3 = TimeSeries(
                             type = TimeSeriesType.GAS_DELIVERY,
                             start = Instant.parse("2022-01-01T00:00:00+01"),
-                            timeStep = 2.hours,
+                            timeStep = DateTimeUnit.HOUR * 2,
                             values = floatArrayOf(1.2f, 2.2f, 3.2f, 4.2f),
                         )
                     ),


### PR DESCRIPTION
Up until now it was only possible to use a time-based step, basically maxing out at the day granularity.

This change makes it possible to use month-based steps.

This is relevant for a few companies in project Hoeksche Waard.

This is only the backend part.