### PR TITLE
Accept NaN/Inf in JSON

### DIFF
--- a/zummon/src/commonMain/kotlin/JsonDecodeSettings.kt
+++ b/zummon/src/commonMain/kotlin/JsonDecodeSettings.kt
@@ -1,0 +1,9 @@
+package com.zenmo.zummon
+
+import kotlinx.serialization.json.Json
+
+// We want to be a bit lenient when decoding.
+// Encoding settings depend on the usecase
+val jsonDecoder = Json {
+    allowSpecialFloatingPointValues = true
+}

--- a/zummon/src/commonMain/kotlin/companysurvey/Survey.kt
+++ b/zummon/src/commonMain/kotlin/companysurvey/Survey.kt
@@ -5,6 +5,7 @@ import com.benasher44.uuid.uuid4
 import kotlinx.serialization.Serializable
 import com.zenmo.zummon.BenasherUuidSerializer
 import com.zenmo.zummon.User
+import com.zenmo.zummon.jsonDecoder
 import kotlinx.datetime.*
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlin.js.JsExport
@@ -191,12 +192,12 @@ data class Survey(
 
 @JsExport
 fun surveyFromJson(json: String): Survey {
-    return kotlinx.serialization.json.Json.decodeFromString(Survey.serializer(), json)
+    return jsonDecoder.decodeFromString(Survey.serializer(), json)
 }
 
 @JsExport
 fun surveysFromJson(json: String): Array<Survey> {
-    return kotlinx.serialization.json.Json.decodeFromString<Array<Survey>>(json)
+    return jsonDecoder.decodeFromString<Array<Survey>>(json)
 }
 
 /**

--- a/zummon/src/commonMain/kotlin/companysurvey/SurveyWithErrors.kt
+++ b/zummon/src/commonMain/kotlin/companysurvey/SurveyWithErrors.kt
@@ -1,5 +1,6 @@
 package com.zenmo.zummon.companysurvey
 
+import com.zenmo.zummon.jsonDecoder
 import kotlinx.serialization.Serializable
 import kotlin.js.JsExport
 
@@ -11,7 +12,7 @@ data class SurveyWithErrors(
 ) {
     companion object {
         fun fromJson(jsonString: String): SurveyWithErrors {
-            return kotlinx.serialization.json.Json.decodeFromString(SurveyWithErrors.serializer(), jsonString)
+            return jsonDecoder.decodeFromString(SurveyWithErrors.serializer(), jsonString)
         }
     }
 

--- a/zummon/src/commonMain/kotlin/companysurvey/TimeSeries.kt
+++ b/zummon/src/commonMain/kotlin/companysurvey/TimeSeries.kt
@@ -7,6 +7,7 @@ import kotlin.time.Duration.Companion.hours
 import com.benasher44.uuid.Uuid
 import com.benasher44.uuid.uuid4
 import com.zenmo.zummon.BenasherUuidSerializer
+import com.zenmo.zummon.jsonDecoder
 import kotlinx.datetime.*
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.PrimitiveKind
@@ -230,7 +231,7 @@ data class TimeSeries (
 }
 
 @JsExport
-fun timeSeriesFromJson(json: String): TimeSeries = Json.decodeFromString(TimeSeries.serializer(), json)
+fun timeSeriesFromJson(json: String): TimeSeries = jsonDecoder.decodeFromString(TimeSeries.serializer(), json)
 
 @JsExport
 enum class TimeSeriesUnit(val label: String) {


### PR DESCRIPTION
It turns out Ktor on default settings sometimes produces invalid JSON which our clients don't accept.

The most convenient fix seems to just accept this.