### PR TITLE
Move deploy variables to repo

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -19,6 +19,13 @@ jobs:
             GITHUB_ENVIRONMENT: ${{ fromJson(steps.variables.outputs.result).GITHUB_ENVIRONMENT }}
             FRONTEND_HOSTNAME: ${{ fromJson(steps.variables.outputs.result).FRONTEND_HOSTNAME }}
             ZTOR_HOSTNAME: ${{ fromJson(steps.variables.outputs.result).ZTOR_HOSTNAME }}
+            AZURE_STORAGE_ACCOUNT_NAME: ${{ fromJson(steps.variables.outputs.result).AZURE_STORAGE_ACCOUNT_NAME }}
+            AZURE_STORAGE_CONTAINER: ${{ fromJson(steps.variables.outputs.result).AZURE_STORAGE_CONTAINER }}
+            DB_NAME: ${{ fromJson(steps.variables.outputs.result).DB_NAME }}
+            MINIO_ACCESS_KEY: ${{ fromJson(steps.variables.outputs.result).MINIO_ACCESS_KEY }}
+            MINIO_ER_EXCEL_UPLOAD_BUCKET: ${{ fromJson(steps.variables.outputs.result).MINIO_ER_EXCEL_UPLOAD_BUCKET }}
+            CORS_ALLOW_ORIGIN_PATTERN: ${{ fromJson(steps.variables.outputs.result).CORS_ALLOW_ORIGIN_PATTERN }}
+            OAUTH_CLIENT_ID: ${{ fromJson(steps.variables.outputs.result).OAUTH_CLIENT_ID }}
         steps:
             -   uses: actions/checkout@v4
                 with:
@@ -117,9 +124,9 @@ jobs:
             image: redgate/flyway:10.2.0
             env:
                 ## TODO: in case of pull request, copy and migrate test database
-                FLYWAY_URL: jdbc:postgresql://postgres.zenmo.com:5432/${{ vars.DB_NAME }}
-                FLYWAY_USER: ${{ vars.DB_NAME }}
-                FLYWAY_PASSWORD: ${{ secrets.DB_PASSWORD }}
+                FLYWAY_URL: jdbc:postgresql://postgres.zenmo.com:5432/${{ needs.variables.outputs.DB_NAME }}
+                FLYWAY_USER: ${{ needs.variables.outputs.DB_NAME }}
+                FLYWAY_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
                 FLYWAY_LOCATIONS: filesystem:./migrations
                 FLYWAY_BASELINE_ON_MIGRATE: true
         steps:
@@ -147,16 +154,16 @@ jobs:
                 uses: sagebind/docker-swarm-deploy-action@v2
                 env:
                     TAG: ${{ needs.variables.outputs.VERSION_TAG }}
-                    FRONTEND_HOSTNAME: ${{ vars.FRONTEND_HOSTNAME || needs.variables.outputs.FRONTEND_HOSTNAME }}
-                    ZTOR_HOSTNAME: ${{ vars.ZTOR_HOSTNAME || needs.variables.outputs.ZTOR_HOSTNAME }}
-                    DB_NAME: ${{ vars.DB_NAME }}
-                    POSTGRES_PASSWORD: ${{ secrets.DB_PASSWORD }}
+                    FRONTEND_HOSTNAME: ${{ needs.variables.outputs.FRONTEND_HOSTNAME }}
+                    ZTOR_HOSTNAME: ${{ needs.variables.outputs.ZTOR_HOSTNAME }}
+                    DB_NAME: ${{ needs.variables.outputs.DB_NAME }}
+                    POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
                     AZURE_STORAGE_ACCOUNT_NAME: zerostore
                     AZURE_STORAGE_ACCOUNT_KEY: ${{ secrets.AZURE_STORAGE_ACCOUNT_KEY }}
-                    AZURE_STORAGE_CONTAINER: ${{ vars.AZURE_STORAGE_CONTAINER }}
-                    MINIO_ER_EXCEL_UPLOAD_BUCKET: ${{ vars.MINIO_ER_EXCEL_UPLOAD_BUCKET }}
-                    CORS_ALLOW_ORIGIN_PATTERN: ${{ vars.CORS_ALLOW_ORIGIN_PATTERN }}
-                    OAUTH_CLIENT_ID: ${{ vars.OAUTH_CLIENT_ID }}
+                    AZURE_STORAGE_CONTAINER: ${{ needs.variables.outputs.AZURE_STORAGE_CONTAINER }}
+                    MINIO_ER_EXCEL_UPLOAD_BUCKET: ${{ needs.variables.outputs.MINIO_ER_EXCEL_UPLOAD_BUCKET }}
+                    CORS_ALLOW_ORIGIN_PATTERN: ${{ needs.variables.outputs.CORS_ALLOW_ORIGIN_PATTERN }}
+                    OAUTH_CLIENT_ID: ${{ needs.variables.outputs.OAUTH_CLIENT_ID }}
                     OAUTH_CLIENT_SECRET: ${{ secrets.OAUTH_CLIENT_SECRET }}
                 with:
                     remote_host: ssh://root@server.zenmo.com

--- a/docker/production/compose.yaml
+++ b/docker/production/compose.yaml
@@ -21,7 +21,7 @@ services:
             POSTGRES_URL: jdbc:postgresql://postgres:5432/${DB_NAME}
             # POSTGRES_URL: jdbc:postgresql://postgres.zenmo.com:5432/${DB_NAME}
             POSTGRES_USER: ${DB_NAME}
-            POSTGRES_PASSWORD: ${DB_PASSWORD}
+            POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
             AZURE_STORAGE_ACCOUNT_NAME: zerostore
             AZURE_STORAGE_ACCOUNT_KEY: ${AZURE_STORAGE_ACCOUNT_KEY}
             AZURE_STORAGE_CONTAINER: ${AZURE_STORAGE_CONTAINER}

--- a/github-actions/get-variables.js
+++ b/github-actions/get-variables.js
@@ -1,6 +1,3 @@
-
-
-
 /**
  * @typedef BuildVariables
  * @type {object}
@@ -30,15 +27,59 @@ module.exports = (context) => {
         .replaceAll(/-*$/g, '') // remove trailing dashes because it would lead to an invalid name
 
     const versionIdentifier = `${shortBranch}-${context.runNumber}`
+    const environment = getEnvironment(context)
 
-    return {
+    const baseVars = {
         ZTOR_PR_CONTAINER_APP_NAME:  `${containerAppBaseName}-${versionIdentifier}`,
         VERSION_TAG: `${versionIdentifier}-${shortCommit}`,
-        DOCKER_STACK_NAME: `zero-${getEnvironment(context)}`,
-        GITHUB_ENVIRONMENT: `swarm-${getEnvironment(context)}`,
-        // handled by wildcard certificate
-        FRONTEND_HOSTNAME: `frontend-${versionIdentifier}.zero.zenmo.com`,
-        ZTOR_HOSTNAME: `ztor-${versionIdentifier}.zero.zenmo.com`,
+        DOCKER_STACK_NAME: `zero-${environment}`,
+        GITHUB_ENVIRONMENT: `swarm-${environment}`,
+        AZURE_STORAGE_ACCOUNT_NAME: "zerostore",
+        // AZURE_STORAGE_ACCOUNT_KEY is a GitHub repository secret
+        // TODO: go to a per-environment Minio access key when we see that the feature is used
+        MINIO_ACCESS_KEY: "admin",
+        // AZURE_SECRET_KEY is a GitHub repository secret
+    }
+
+    const environmentSpecificVars = {
+        production: {
+            FRONTEND_HOSTNAME: "zero.zenmo.com",
+            ZTOR_HOSTNAME: "ztor.zero.zenmo.com",
+            DB_NAME: "zero_production",
+            // POSTGRES_PASSWORD is a GitHub environment secret
+            AZURE_STORAGE_CONTAINER: "prod",
+            MINIO_ER_EXCEL_UPLOAD_BUCKET: "energieke-regio-excel-uploads-production",
+            CORS_ALLOW_ORIGIN_PATTERN: "https://zero.zenmo.com",
+            OAUTH_CLIENT_ID: "zero-configurator-prod",
+            // OAUTH_CLIENT_SECRET is a GitHub environment secret
+        },
+        test: {
+            FRONTEND_HOSTNAME: "zero-test.zenmo.com",
+            ZTOR_HOSTNAME: "ztor-test.zero.zenmo.com",
+            DB_NAME: "zero_test",
+            // POSTGRES_PASSWORD is a GitHub environment secret
+            AZURE_STORAGE_CONTAINER: "test",
+            MINIO_ER_EXCEL_UPLOAD_BUCKET: "energieke-regio-excel-uploads-test",
+            CORS_ALLOW_ORIGIN_PATTERN: "https://zero-test.zenmo.com",
+            OAUTH_CLIENT_ID: "zero-configurator-test",
+            // OAUTH_CLIENT_SECRET is a GitHub environment secret
+        },
+        pullrequest: {
+            FRONTEND_HOSTNAME: `frontend-${versionIdentifier}.zero.zenmo.com`,
+            ZTOR_HOSTNAME: `ztor-${versionIdentifier}.zero.zenmo.com`,
+            DB_NAME: "zero_pullrequest",
+            // POSTGRES_PASSWORD is a GitHub environment secret
+            AZURE_STORAGE_CONTAINER: "dev",
+            MINIO_ER_EXCEL_UPLOAD_BUCKET: "energieke-regio-excel-uploads-pullrequest",
+            CORS_ALLOW_ORIGIN_PATTERN: "https://frontend-[\\\\w-]+.zero.zenmo.com",
+            OAUTH_CLIENT_ID: "zero-configurator-test",
+            // OAUTH_CLIENT_SECRET is a GitHub environment secret
+        },
+    }
+
+    return {
+        ...baseVars,
+        ...environmentSpecificVars[environment],
     }
 }
 


### PR DESCRIPTION
Deploy variables used to be in GitHub environments. This moves them to the repository.

Secrets are still in GitHub action secrets. In the future it's desirable to save them as Docker or Podman secrets.