### PR TITLE
Add kotlinx.rpc

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -111,6 +111,7 @@ jobs:
                     tags: ghcr.io/zenmo/zero-frontend:${{ needs.variables.outputs.VERSION_TAG }}
                     build-args: |
                         VITE_ZTOR_URL=https://${{ vars.ZTOR_HOSTNAME || needs.variables.outputs.ZTOR_HOSTNAME }}
+                        VITE_ZTOR_RPC_URL=wss://${{ vars.ZTOR_HOSTNAME || needs.variables.outputs.ZTOR_HOSTNAME }}/rpc
                         BROWSER_CACHE_KEY=${{ steps.browser-cache-key.outputs.stdout }}
                     cache-from: type=gha
                     cache-to: type=gha,mode=max

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     // need to specify version here because this plugin in used in multiple subprojects
     kotlin("jvm") version "2.2.21" apply false
     kotlin("plugin.serialization") version "2.2.21" apply false
+    id("org.jetbrains.kotlinx.rpc.plugin") version "0.10.1" apply false
 
     // some tooling seems to prefer this format
     //    id("org.jetbrains.kotlin.plugin.serialization") version "2.0.0" apply false

--- a/docker/production/frontend/Dockerfile
+++ b/docker/production/frontend/Dockerfile
@@ -9,6 +9,7 @@ RUN --mount=type=cache,target=/home/gradle/.gradle/caches gradle joshi:jsBrowser
 
 FROM node:22 AS node
 ARG VITE_ZTOR_URL
+ARG VITE_ZTOR_RPC_URL
 ARG BROWSER_CACHE_KEY
 
 RUN mkdir -p /app/frontend

--- a/frontend/src/admin/surveys.tsx
+++ b/frontend/src/admin/surveys.tsx
@@ -15,6 +15,8 @@ import {ActionButtonPair} from "../components/helpers/ActionButtonPair"
 import {useNavigate} from "react-router-dom"
 import {Content} from "../components/Content"
 import {IndexSurveySelectAction} from "./index-survey-select-action"
+import {useOnce} from "../hooks/use-once"
+import {IndexSurveyClient} from "joshi"
 
 export const Surveys: FunctionComponent = () => {
     const {

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -6,6 +6,7 @@ import { RouterProvider } from "react-router-dom";
 import { router } from "./router";
 import './_zenmo-zero/assets/style.scss'
 import './_zenmo-zero/assets/style.react.scss'
+import {IndexSurveyClient, IndexSurveyList} from "joshi"
 
 const root = ReactDOM.createRoot(
     document.getElementById('root') as HTMLElement,
@@ -20,3 +21,9 @@ root.render(
 // to log results (for example: reportWebVitals(console.log))
 // or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
 reportWebVitals()
+
+export async function testRpcClient(): Promise<void> {
+    const client = new IndexSurveyClient()
+    const surveyList = await client.fetchIndexSurveys()
+    console.log(surveyList)
+}

--- a/joshi/build.gradle.kts
+++ b/joshi/build.gradle.kts
@@ -3,6 +3,7 @@ import java.net.URI
 plugins {
     kotlin("multiplatform")
     kotlin("plugin.serialization")
+    id("org.jetbrains.kotlinx.rpc.plugin")
 }
 
 group = "com.zenmo"
@@ -29,6 +30,7 @@ kotlin {
         }
         commonMain {
             dependencies {
+                implementation("org.jetbrains.kotlinx:kotlinx-rpc-core:${libs.versions.kotlinx.rpc.get()}")
                 implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:${libs.versions.kotlinx.serialization.json.get()}")
                 implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:${libs.versions.kotlinx.serialization.json.get()}")
                 implementation("org.jetbrains.kotlinx:kotlinx-datetime:${libs.versions.kotlinx.datetime.get()}")
@@ -45,6 +47,13 @@ kotlin {
                 // align versions with frontend
                 implementation(npm("@js-joda/core", "^5.6.3"))
                 implementation(npm("@js-joda/timezone", "^2.21.1"))
+
+                implementation("org.jetbrains.kotlinx:kotlinx-rpc-krpc-client:${libs.versions.kotlinx.rpc.get()}")
+                implementation("org.jetbrains.kotlinx:kotlinx-rpc-krpc-serialization-json:${libs.versions.kotlinx.rpc.get()}")
+                implementation("org.jetbrains.kotlinx:kotlinx-rpc-krpc-ktor-client:${libs.versions.kotlinx.rpc.get()}")
+
+                implementation("io.ktor:ktor-client-core:${libs.versions.ktor.get()}")
+                implementation("io.ktor:ktor-client-js:${libs.versions.ktor.get()}")
             }
         }
     }

--- a/joshi/src/commonMain/kotlin/IndexSurvey.kt
+++ b/joshi/src/commonMain/kotlin/IndexSurvey.kt
@@ -1,15 +1,13 @@
 package com.zenmo.joshi
 
-import com.zenmo.zummon.companysurvey.Survey
 import com.zenmo.zummon.jsonDecoder
 import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
-import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsExport
 import kotlin.uuid.Uuid
 
 /**
- * A variant of the company survey which has less properties
+ * A variant of the company survey which has fewer properties
  * so it can be used for a list on a web page.
  */
 @JsExport

--- a/joshi/src/commonMain/kotlin/IndexSurveyList.kt
+++ b/joshi/src/commonMain/kotlin/IndexSurveyList.kt
@@ -1,0 +1,15 @@
+package com.zenmo.joshi
+
+import kotlinx.serialization.Serializable
+import kotlin.js.JsExport
+
+@JsExport
+@Serializable
+data class IndexSurveyList(
+    val records: List<IndexSurvey>,
+    /**
+     * Total number of Survey records matching the query.
+     * Can be more than [records.size] if a limit or offset was used.
+     */
+    val numberOfMatches: Int,
+)

--- a/joshi/src/commonMain/kotlin/IndexSurveyService.kt
+++ b/joshi/src/commonMain/kotlin/IndexSurveyService.kt
@@ -1,0 +1,8 @@
+package com.zenmo.joshi
+
+import kotlinx.rpc.annotations.Rpc
+
+@Rpc
+interface IndexSurveyService {
+    suspend fun fetchIndexSurveys(): IndexSurveyList
+}

--- a/joshi/src/jsMain/kotlin/IndexSurveyClient.kt
+++ b/joshi/src/jsMain/kotlin/IndexSurveyClient.kt
@@ -1,0 +1,20 @@
+package com.zenmo.joshi
+
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.promise
+import kotlinx.rpc.withService
+import kotlin.js.Promise
+
+/**
+ * Wraps IndexSurveyService because suspend functions can't be exported to JavaScript.
+ */
+@JsExport
+class IndexSurveyClient(
+    val wrappedService: IndexSurveyService = rpcClient.withService(IndexSurveyService::class)
+) {
+    fun fetchIndexSurveys(): Promise<IndexSurveyList> {
+        return GlobalScope.promise {
+            wrappedService.fetchIndexSurveys()
+        }
+    }
+}

--- a/joshi/src/jsMain/kotlin/RpcClient.kt
+++ b/joshi/src/jsMain/kotlin/RpcClient.kt
@@ -1,0 +1,26 @@
+package com.zenmo.joshi
+
+import io.ktor.client.*
+import kotlinx.rpc.RpcClient
+import kotlinx.rpc.krpc.ktor.client.installKrpc
+import kotlinx.rpc.krpc.ktor.client.rpc
+import kotlinx.rpc.krpc.serialization.json.json
+
+/**
+ * This should only be called once so all services share the same websocket.
+ */
+fun createRpcClient(
+    rpcUrl: String = js("import.meta.env.VITE_ZTOR_RPC_URL") ?: "ws://localhost:8082/rpc"
+): RpcClient {
+    val ktorClient = HttpClient {
+        installKrpc {
+            serialization {
+                json()
+            }
+        }
+    }
+
+    return ktorClient.rpc(rpcUrl)
+}
+
+val rpcClient by lazy { createRpcClient() }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,8 @@ dependencyResolutionManagement {
             version("exposed", "0.59.0")
             version("kotlinx-serialization-json", "1.8.0")
             version("kotlinx-datetime", "0.6.1")
+            version("kotlinx-rpc", "0.10.1")
+            version("ktor", "3.3.3")
         }
     }
 }

--- a/ztor/build.gradle.kts
+++ b/ztor/build.gradle.kts
@@ -1,11 +1,10 @@
 
-val ktor_version = "3.3.3"
-
 plugins {
     kotlin("jvm")
 
-    id("io.ktor.plugin") version "3.3.3"
+    id("io.ktor.plugin") version libs.versions.ktor.get()
     kotlin("plugin.serialization")
+    id("org.jetbrains.kotlinx.rpc.plugin")
 }
 
 group = "com.zenmo"
@@ -44,29 +43,33 @@ dependencies {
     implementation("org.jetbrains.exposed:exposed-core:${libs.versions.exposed.get()}")
 
     implementation("ch.qos.logback:logback-classic:1.4.12")
-    implementation("io.ktor:ktor-serialization-kotlinx-json-jvm:$ktor_version")
-    implementation("io.ktor:ktor-server-auth:$ktor_version")
-    implementation("io.ktor:ktor-server-call-logging-jvm:$ktor_version")
-    implementation("io.ktor:ktor-server-content-negotiation-jvm:$ktor_version")
-    implementation("io.ktor:ktor-server-core-jvm:$ktor_version")
-    implementation("io.ktor:ktor-server-cors-jvm:$ktor_version")
-    implementation("io.ktor:ktor-server-host-common-jvm:$ktor_version")
-    implementation("io.ktor:ktor-server-html-builder:$ktor_version")
-    implementation("io.ktor:ktor-server-netty-jvm:$ktor_version")
-    implementation("io.ktor:ktor-server-status-pages-jvm:$ktor_version")
-    implementation("io.ktor:ktor-server-status-pages:$ktor_version")
+    implementation("io.ktor:ktor-serialization-kotlinx-json-jvm:${libs.versions.ktor.get()}")
+    implementation("io.ktor:ktor-server-auth:${libs.versions.ktor.get()}")
+    implementation("io.ktor:ktor-server-call-logging-jvm:${libs.versions.ktor.get()}")
+    implementation("io.ktor:ktor-server-content-negotiation-jvm:${libs.versions.ktor.get()}")
+    implementation("io.ktor:ktor-server-core-jvm:${libs.versions.ktor.get()}")
+    implementation("io.ktor:ktor-server-cors-jvm:${libs.versions.ktor.get()}")
+    implementation("io.ktor:ktor-server-host-common-jvm:${libs.versions.ktor.get()}")
+    implementation("io.ktor:ktor-server-html-builder:${libs.versions.ktor.get()}")
+    implementation("io.ktor:ktor-server-netty-jvm:${libs.versions.ktor.get()}")
+    implementation("io.ktor:ktor-server-status-pages-jvm:${libs.versions.ktor.get()}")
+    implementation("io.ktor:ktor-server-status-pages:${libs.versions.ktor.get()}")
     // kinda need this to run in Azure Container Apps
     // https://learn.microsoft.com/en-us/azure/container-apps/ingress-overview#http-headers
-    implementation("io.ktor:ktor-server-forwarded-header:$ktor_version")
+    implementation("io.ktor:ktor-server-forwarded-header:${libs.versions.ktor.get()}")
 
     // I experience performance issues with Ktor's multipart handling.
     implementation(platform("org.http4k:http4k-bom:5.30.0.0"))
     implementation("org.http4k:http4k-multipart")
 
     // to call into Keycloak
-    implementation("io.ktor:ktor-client-core:$ktor_version")
-    implementation("io.ktor:ktor-client-cio:$ktor_version")
-    implementation("io.ktor:ktor-client-content-negotiation:$ktor_version")
+    implementation("io.ktor:ktor-client-core:${libs.versions.ktor.get()}")
+    implementation("io.ktor:ktor-client-cio:${libs.versions.ktor.get()}")
+    implementation("io.ktor:ktor-client-content-negotiation:${libs.versions.ktor.get()}")
+
+    implementation("org.jetbrains.kotlinx:kotlinx-rpc-krpc-server:${libs.versions.kotlinx.rpc.get()}")
+    implementation("org.jetbrains.kotlinx:kotlinx-rpc-krpc-ktor-server:${libs.versions.kotlinx.rpc.get()}")
+    implementation("org.jetbrains.kotlinx:kotlinx-rpc-krpc-serialization-json:${libs.versions.kotlinx.rpc.get()}")
 
     // to hash deeplink secrets
     implementation("at.favre.lib:bcrypt:0.10.2")
@@ -81,7 +84,7 @@ dependencies {
     // minio for excel uploads storage
     implementation("io.minio:minio:8.5.17")
 
-    testImplementation("io.ktor:ktor-server-test-host:$ktor_version")
+    testImplementation("io.ktor:ktor-server-test-host:${libs.versions.ktor.get()}")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:2.0.20")
     testImplementation("org.jetbrains.kotlin:kotlin-test")
 }

--- a/ztor/src/main/kotlin/com/zenmo/ztor/Application.kt
+++ b/ztor/src/main/kotlin/com/zenmo/ztor/Application.kt
@@ -6,6 +6,7 @@ import com.zenmo.orm.connectToPostgres
 import com.zenmo.orm.createSchema
 import com.zenmo.orm.echoSchemaSql
 import com.zenmo.ztor.plugins.*
+import com.zenmo.ztor.rpc.configureRpc
 import com.zenmo.zummon.companysurvey.surveysToJson
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
@@ -75,4 +76,5 @@ fun Application.module() {
     configureStatusPages()
     configureUpload(db)
     configureExcel(db)
+    configureRpc(db)
 }

--- a/ztor/src/main/kotlin/com/zenmo/ztor/rpc/IndexSurveyServiceImpl.kt
+++ b/ztor/src/main/kotlin/com/zenmo/ztor/rpc/IndexSurveyServiceImpl.kt
@@ -1,0 +1,13 @@
+package com.zenmo.ztor.rpc
+
+import com.zenmo.joshi.IndexSurveyList
+import com.zenmo.joshi.IndexSurveyService
+import com.zenmo.orm.companysurvey.SurveyRepository
+
+class IndexSurveyServiceImpl(
+    val surveyRepository: SurveyRepository
+): IndexSurveyService {
+    override suspend fun fetchIndexSurveys(): IndexSurveyList {
+        return IndexSurveyList(emptyList(), 0)
+    }
+}

--- a/ztor/src/main/kotlin/com/zenmo/ztor/rpc/RpcKtorModule.kt
+++ b/ztor/src/main/kotlin/com/zenmo/ztor/rpc/RpcKtorModule.kt
@@ -1,0 +1,27 @@
+package com.zenmo.ztor.rpc
+
+import com.zenmo.joshi.IndexSurveyService
+import com.zenmo.orm.companysurvey.SurveyRepository
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.routing.routing
+import kotlinx.rpc.krpc.ktor.server.Krpc
+import kotlinx.rpc.krpc.ktor.server.rpc
+import kotlinx.rpc.krpc.serialization.json.json
+import org.jetbrains.exposed.sql.Database
+
+fun Application.configureRpc(db: Database) {
+    install(Krpc) {
+        serialization {
+            json()
+        }
+    }
+
+    routing {
+        rpc("/rpc") {
+            registerService<IndexSurveyService> {
+                IndexSurveyServiceImpl(SurveyRepository(db))
+            }
+        }
+    }
+}


### PR DESCRIPTION
I want to add filtering and pagination to to the REST endpoint /index-surveys and it seemed like an opportunity to introduce kotlinx.rpc in order to reduce friction.

This can be seen as a controversial choice. REST is very common and kRPC is not based on a standard that is implemented by other programming languages.

You can test it in the browser console:

```
const {testRpcClient} = await import("/src/index.tsx")
testRpcClient()
```

It should log something like

```
Object { records: {…}, numberOfMatches: 0 }
```