### PR TITLE
Excel set charge point power to null

### DIFF
--- a/excel-read-named-v5/src/main/kotlin/excelreadnamed/v5/CompanyDataDocument.kt
+++ b/excel-read-named-v5/src/main/kotlin/excelreadnamed/v5/CompanyDataDocument.kt
@@ -191,10 +191,8 @@ data class CompanyDataDocument(
                                             "numElectricTrucks"
                                         )
                                             .toInt(),
-                                        numChargePoints =
-                                        0,
-                                        powerPerChargePointKw =
-                                        0f,
+                                        numChargePoints = null,
+                                        powerPerChargePointKw = null,
                                         annualTravelDistancePerTruckKm =
                                         getNumericField(
                                             "annualTravelDistancePerTruckKm"
@@ -215,10 +213,8 @@ data class CompanyDataDocument(
                                             "numElectricVans"
                                         )
                                             .toInt(),
-                                        numChargePoints =
-                                        0,
-                                        powerPerChargePointKw =
-                                        0f,
+                                        numChargePoints = null,
+                                        powerPerChargePointKw = null,
                                         annualTravelDistancePerVanKm =
                                         getNumericField(
                                             "annualTravelDistancePerVanKm"


### PR DESCRIPTION
For trucks and vans. All charge point data is set under cars.

Setting it to null prevents validation errors as it is regarded as missing data.