### PR TITLE
  add `toDrivingHourMatrix` for Anylogic boolean[7][24] output

### DIFF
--- a/vallum/build.gradle.kts
+++ b/vallum/build.gradle.kts
@@ -36,6 +36,14 @@ dependencies {
     implementation("com.zenmo:bag:0.0.2")
 }
 
+kotlin {
+    sourceSets {
+        all {
+            languageSettings.optIn("kotlin.uuid.ExperimentalUuidApi")
+        }
+    }
+}
+
 tasks.withType<Test> {
     this.testLogging {
         this.showStandardStreams = true

--- a/vallum/src/main/kotlin/DriveSchedule.kt
+++ b/vallum/src/main/kotlin/DriveSchedule.kt
@@ -1,0 +1,32 @@
+package com.zenmo.vallum
+
+import com.zenmo.zummon.companysurvey.DriveSchedule
+import kotlinx.datetime.LocalTime
+
+/**
+ * Derives a 7×24 boolean matrix from a list of drive schedules.
+ * Rows are days of the week (Monday=0 … Sunday=6).
+ * Columns are hours of the day (0–23).
+ * true = vehicle is driving (not available for charging) during that hour.
+ *
+ * Multiple schedules are OR-ed together: if any schedule has a trip covering an hour,
+ * that hour is marked true.
+ */
+fun toDrivingHourMatrix(driveSchedules: List<DriveSchedule>): Array<BooleanArray> {
+    val matrix = Array(7) { BooleanArray(24) }
+
+    for (schedule in driveSchedules) {
+        for (trip in schedule.trips) {
+            val dayIndex = trip.dayOfWeek.value - 1 // MONDAY=1 → 0, SUNDAY=7 → 6
+            for (h in trip.startTime.hour until trip.endTime.hour) {
+                matrix[dayIndex][h] = true
+            }
+            // If the vehicle returns mid-hour (e.g. 17:30), that hour is also driving time
+            if (trip.endTime > LocalTime(trip.endTime.hour, 0)) {
+                matrix[dayIndex][trip.endTime.hour] = true
+            }
+        }
+    }
+
+    return matrix
+}

--- a/vallum/src/test/kotlin/DriveScheduleTest.kt
+++ b/vallum/src/test/kotlin/DriveScheduleTest.kt
@@ -1,0 +1,76 @@
+package com.zenmo.vallum
+
+import com.zenmo.zummon.companysurvey.DriveSchedule
+import com.zenmo.zummon.companysurvey.Trip
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalTime
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DriveScheduleTest {
+
+    @Test
+    fun testSingleTripMarksCorrectDayAndHours() {
+        // Monday 08:00–17:00
+        val schedules = listOf(
+            DriveSchedule(
+                nVehicles = 1,
+                trips = listOf(Trip(DayOfWeek.MONDAY, LocalTime(8, 0), LocalTime(17, 0))),
+            )
+        )
+
+        val matrix = toDrivingHourMatrix(schedules)
+
+        // Monday = index 0
+        assertFalse(matrix[0][7], "Hour 7 should be false (vehicle not yet gone)")
+        assertTrue(matrix[0][8], "Hour 8 should be true")
+        assertTrue(matrix[0][16], "Hour 16 should be true")
+        assertFalse(matrix[0][17], "Hour 17 should be false (vehicle back at exactly 17:00)")
+
+        // Other days untouched
+        assertFalse(matrix[1][8], "Tuesday hour 8 should be false")
+    }
+
+    @Test
+    fun testMidHourArrivalMarksPartialHourAsDriving() {
+        // Monday 08:00–17:30: hour 17 should be marked because vehicle returns at 17:30
+        val schedules = listOf(
+            DriveSchedule(
+                nVehicles = 1,
+                trips = listOf(Trip(DayOfWeek.MONDAY, LocalTime(8, 0), LocalTime(17, 30))),
+            )
+        )
+
+        val matrix = toDrivingHourMatrix(schedules)
+
+        assertTrue(matrix[0][17], "Hour 17 should be true when vehicle returns at 17:30")
+        assertFalse(matrix[0][18], "Hour 18 should be false")
+    }
+
+    @Test
+    fun testMultipleSchedulesAreORedTogether() {
+        // Schedule A: Monday 06:00–10:00
+        // Schedule B: Monday 14:00–18:00
+        val schedules = listOf(
+            DriveSchedule(
+                nVehicles = 2,
+                trips = listOf(Trip(DayOfWeek.MONDAY, LocalTime(6, 0), LocalTime(10, 0))),
+            ),
+            DriveSchedule(
+                nVehicles = 3,
+                trips = listOf(Trip(DayOfWeek.MONDAY, LocalTime(14, 0), LocalTime(18, 0))),
+            ),
+        )
+
+        val matrix = toDrivingHourMatrix(schedules)
+
+        assertTrue(matrix[0][6])
+        assertTrue(matrix[0][9])
+        assertFalse(matrix[0][10])
+        assertFalse(matrix[0][13])
+        assertTrue(matrix[0][14])
+        assertTrue(matrix[0][17])
+        assertFalse(matrix[0][18])
+    }
+}


### PR DESCRIPTION
 Derives a 7×24 boolean matrix from a list of drive schedules.
 Rows are days of the week (Monday=0 … Sunday=6).
 Columns are hours of the day (0–23).
 true = vehicle is driving (not available for charging) during that hour.
 
Multiple schedules are OR-ed together: if any schedule has a trip covering an hour, that hour is marked true.

Engineered with Claude-Sonnet-4-6